### PR TITLE
Introduce Bounded Integers to Reflect the EMC2101 Register Specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "emc2101"
 repository = "https://github.com/Georges760/emc2101-rs"
 rust-version = "1.71.1"
-version = "1.0.0"
+version = "2.0.0"
 
 [dependencies]
 bounded-integer = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rust-version = "1.71.1"
 version = "1.0.0"
 
 [dependencies]
+bounded-integer = "0.6.0"
 defmt = { version = "0.3", optional = true }
 embedded-hal = { version = "1.0", optional = true }
 embedded-hal-async = { version = "1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl From<u8> for Status {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Level {
     pub temp: BoundedU8<0, 127>,
-    pub step: BoundedU8<0, 64>,
+    pub step: BoundedU8<0, 63>,
 }
 
 /// Manual implementation of defmt 'Format' trait, since BoundedU8 does not implement it.


### PR DESCRIPTION
This PR is result of #1

Long story short, according to [EMC2101 specification 5.18](https://ww1.microchip.com/downloads/aemDocuments/documents/MSLD/ProductDocuments/DataSheets/EMC2101-Data-Sheet-DS20006703.pdf) Fan Setting Register accepts decimal within range 0 and 63, but driver formula doesn't guarantee that percent value you supplied will get into that range.

To tackle the issue this PR introduces bounded integers for Fan Setting and allows user to select directly desired step level without intermediate mapping from percent to register's final value.

Additional changes according to the specification, allow us to remove conditional checks if values are within correct range and unlock compile time warnings.
- `temp` field of the `Level` struct became bounded within range 0 and 127
- `hysteresis` parameter of `set_fan_lut` became bounded within range 0 and 31

@Georges760 please review the PR, don't mind correcting my grammar and proposing better names for the variables :)