### PR TITLE
Switch to maintained fork for `maybe-async-cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ embedded-hal-async = { version = "1.0", optional = true }
 fugit = "0.3"
 heapless = "0.9"
 log = { version = "0.4", optional = true }
-maybe-async-cfg = "0.2"
+maybe-async-cfg2 = { version = "0.3" }
 rustversion = "1.0"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ impl defmt::Format for Level {
 ///
 /// The address of the sensor will be `DEFAULT_ADDRESS` from this package,
 /// unless there is some kind of special address translating hardware in use.
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(feature = "sync", self = "EMC2101"),
     async(feature = "async", keep_self)
 )]
@@ -165,7 +165,7 @@ pub struct AsyncEMC2101<I> {
     variant: Option<Product>,
 }
 
-#[maybe_async_cfg::maybe(
+#[maybe_async_cfg2::maybe(
     sync(
         feature = "sync",
         self = "EMC2101",


### PR DESCRIPTION
I forked `maybe-async-cfg` (which itself is a fork of `maybe-async`), cleaned up the docs a bit, and published it at `maybe-async-cfg2`

https://crates.io/crates/maybe-async-cfg2